### PR TITLE
Add initial support for building the project using CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(CIL
+       VERSION 0.1.0
+       LANGUAGES C CXX
+       DESCRIPTION "C++ Image Library")
+
+find_package(PkgConfig REQUIRED)
+
+option(LIBPNG_DIR "Path to libpng installation directory")
+option(LIBJPEG_DIR "Path to libjpeg installation directory")
+option(CIL_BUILD_EXAMPLES "Specify if examples should be added and built")
+
+if(ENV{PKG_CONFIG_PATH})
+    set(pkg_config_path $ENV{PKG_CONFIG_PATH})
+    string(REPLACE ":" ";" prefix_paths ${pkg_config_path})
+    list(APPEND CMAKE_PREFIX_PATH ${prefix_paths})
+endif()
+
+if(LIBPNG_DIR)
+    list(PREPEND CMAKE_PREFIX_PATH ${LIBPNG_DIR})
+endif()
+    
+if(LIBJPEG_DIR)
+    list(PREPEND CMAKE_PREFIX_PATH ${LIBJPEG_DIR})
+endif()
+    
+pkg_check_modules(LIBPNG libpng=1.6.37)
+if(LIBPNG_FOUND)
+    set(CIL_ENABLE_PNG true)
+    string(CONCAT libpng_found_message "Libpng ${LIBPNG_VERSION} will "
+           "be used to add PNG support to the project.")
+    message(STATUS ${libpng_found_message})
+else()
+    set(CIL_ENABLE_PNG false)
+    if (LIBPNG_DIR)
+        string(CONCAT libpng_not_found_warning "Libpng pkg config file not found. "
+               "Project is being configured to be built without the PNG support.")
+        message(WARNING ${libpng_not_found_warning})
+    endif()
+endif()
+
+pkg_check_modules(LIBJPEG libjpeg=9.4.0)
+if(LIBJPEG_FOUND)
+    set(CIL_ENABLE_JPEG true)
+    string(CONCAT libjpeg_found_message "Libjpeg ${LIBJPEG_VERSION} will "
+           "be used to add JPEG support to the project.")
+    message(STATUS ${libjpeg_found_message})
+else()
+    set(CIL_ENABLE_JPEG false)
+    if (LIBJPEG_DIR)
+        string(CONCAT libjpeg_not_found_warning "Libjpeg pkg config file not found. "
+               "Project is being configured to be built without the JPEG support.")
+        message(WARNING ${libjpeg_not_found_warning})
+    endif()
+endif()
+
+add_subdirectory(lib)
+
+if(CIL_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
+install(DIRECTORY include/ TYPE INCLUDE)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,38 @@
+include_directories(${CMAKE_SOURCE_DIRECTORY}/include)
+link_directories(${CMAKE_BINARY_DIR}/lib)
+link_libraries(cil)
+
+if(BUILD_SHARED_LIBS)
+    list(APPEND CMAKE_BUILD_RPATH ${CMAKE_BINARY_DIR}/lib)
+    list(APPEND CMAKE_INSTALL_RPATH ${CMAKE_BINARY_DIR}/lib)
+endif()
+
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        DESTINATION ${CMAKE_INSTALL_PREFIX}
+        FILES_MATCHING REGEX ".*\.(jpeg|jpg|png)")
+
+if (CIL_ENABLE_PNG)
+    list(APPEND CMAKE_BUILD_RPATH ${LIBPNG_LIBRARY_DIRS})
+    list(APPEND CMAKE_INSTALL_RPATH ${LIBPNG_LIBRARY_DIRS})
+    if (NOT BUILD_SHARED_LIBS)
+        link_directories(${LIBPNG_LIBRARY_DIRS})
+        link_libraries(${LIBPNG_LIBRARIES})
+    endif()
+endif()
+    
+if (CIL_ENABLE_JPEG)
+    list(APPEND CMAKE_BUILD_RPATH ${LIBJPEG_LIBRARY_DIRS})
+    list(APPEND CMAKE_INSTALL_RPATH ${LIBJPEG_LIBRARY_DIRS})
+    if (NOT BUILD_SHARED_LIBS)
+        link_directories(${LIBJPEG_LIBRARY_DIRS})
+        link_libraries(${LIBJPEG_LIBRARIES})
+    endif()
+endif()
+
+if (CIL_ENABLE_PNG)
+    add_subdirectory(PNG)
+endif()
+
+if (CIL_ENABLE_JPEG)
+    add_subdirectory(JPEG)
+endif()

--- a/examples/JPEG/CMakeLists.txt
+++ b/examples/JPEG/CMakeLists.txt
@@ -1,0 +1,12 @@
+file(GLOB 
+     example_files
+     LIST_DIRECTORIES false
+     CONFIGURE_DEPENDS
+     *.cpp)
+
+foreach(example_file IN LISTS example_files)
+    get_filename_component(example ${example_file} NAME_WE)
+    add_executable(${example} ${example_file})
+    install(TARGETS ${example} 
+            DESTINATION examples/JPEG)
+endforeach()

--- a/examples/PNG/CMakeLists.txt
+++ b/examples/PNG/CMakeLists.txt
@@ -1,0 +1,12 @@
+file(GLOB 
+     example_files
+     LIST_DIRECTORIES false
+     CONFIGURE_DEPENDS
+     *.cpp)
+
+foreach(example_file IN LISTS example_files)
+    get_filename_component(example ${example_file} NAME_WE)
+    add_executable(${example} ${example_file})
+    install(TARGETS ${example} 
+            DESTINATION examples/PNG)
+endforeach()

--- a/include/CIL/PNG/PNGCore.hpp
+++ b/include/CIL/PNG/PNGCore.hpp
@@ -1,6 +1,6 @@
 #ifndef CIL_PNGCORE_HPP
 #define CIL_PNGCORE_HPP
-#include <libpng16/png.h>
+#include <png.h>
 
 #include <setjmp.h>
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,25 @@
+add_library(cil ImageInfo.cpp)
+
+if (CIL_ENABLE_JPEG)
+    target_compile_definitions(cil PUBLIC CIL_JPEG_ENABLED)
+endif()
+
+if (CIL_ENABLE_PNG)
+    target_compile_definitions(cil PUBLIC CIL_PNG_ENABLED)
+endif()
+
+target_include_directories(cil PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+if(CIL_ENABLE_PNG)
+    add_subdirectory(PNG)
+endif()
+
+if(CIL_ENABLE_JPEG)
+    add_subdirectory(JPEG)
+endif()
+
+target_include_directories(cil PUBLIC ${HEADERS})
+
+install(TARGETS cil 
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib)

--- a/lib/ImageInfo.cpp
+++ b/lib/ImageInfo.cpp
@@ -1,6 +1,10 @@
 #include <CIL/ImageInfo.hpp>
+#ifdef CIL_JPEG_ENABLED
 #include <CIL/JPEG/JPEGHandler.hpp>
+#endif
+#ifdef CIL_PNG_ENABLED
 #include <CIL/PNG/PNGHandler.hpp>
+#endif
 
 namespace CIL {
     void ImageInfo::print_image_info()
@@ -14,10 +18,12 @@ namespace CIL {
     {
         switch (img_info->image_type)
         {
-            case ImageType::JPEG:
-                // JPEG::JpegHandler::destroy(img_info);
-                break;
+#ifdef CIL_JPEG_ENABLED
+            case ImageType::JPEG: JPEG::JpegHandler::destroy(img_info); break;
+#endif
+#ifdef CIL_PNG_ENABLED
             case ImageType::PNG: PNG::destroyPNGImageInfo(img_info); break;
+#endif
             case ImageType::PPM: break;
         }
         delete[] img_info->data;

--- a/lib/JPEG/CMakeLists.txt
+++ b/lib/JPEG/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(JPEG_SPECIFIC_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/JPEGCore.cpp ${CMAKE_CURRENT_SOURCE_DIR}/JPEGHandler.cpp)
+
+target_sources(cil PUBLIC ${JPEG_SPECIFIC_SOURCES})
+
+get_target_property(cil_target_type cil TYPE)
+
+target_include_directories(cil PUBLIC ${LIBJPEG_INCLUDE_DIRS})
+
+if(cil_target_type STREQUAL "SHARED_LIBRARY")
+  target_link_directories(cil PUBLIC ${LIBJPEG_LIBRARY_DIRS})
+  target_link_libraries(cil PUBLIC ${LIBJPEG_LIBRARIES})
+endif()

--- a/lib/PNG/CMakeLists.txt
+++ b/lib/PNG/CMakeLists.txt
@@ -1,0 +1,12 @@
+set(PNG_SPECIFIC_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/PNGCore.cpp ${CMAKE_CURRENT_SOURCE_DIR}/PNGHandler.cpp)
+
+target_sources(cil PUBLIC ${PNG_SPECIFIC_SOURCES})
+
+get_target_property(cil_target_type cil TYPE)
+
+target_include_directories(cil PUBLIC ${LIBPNG_INCLUDE_DIRS})
+
+if(cil_target_type STREQUAL "SHARED_LIBRARY")
+  target_link_directories(cil PUBLIC ${LIBPNG_LIBRARY_DIRS})
+  target_link_libraries(cil PUBLIC ${LIBPNG_LIBRARIES})
+endif()

--- a/lib/PNG/PNGHandler.cpp
+++ b/lib/PNG/PNGHandler.cpp
@@ -1,7 +1,7 @@
 #include <CIL/ImageInfo.hpp>
 #include <CIL/PNG/PNGCore.hpp>
 #include <CIL/PNG/PNGHandler.hpp>
-#include <libpng16/png.h>
+#include <png.h>
 
 namespace CIL {
     namespace PNG {


### PR DESCRIPTION
This PR adds CMake configuration files to easily build the project. 

By default, CMake will search for `libjpeg` and `libpng` pkg config files in the paths described by `PKG_CONFIG_PATH` environment variable.

Additional CMake configuration options provided are as follows:

- `LIBPNG_DIR`: Path of the `libpng` installation directory. If provided, `libpng` found through `LIBPNG_DIR` path will be preferred over `libpng` found through `PKG_CONFIG_PATH`.

 - `LIBJPEG_DIR`: Path of the `libjpeg` installation directory. If provided, `libjpeg` found through `LIBJPEG_DIR` path will be preferred over `libjpeg` found through `PKG_CONFIG_PATH`.
 
 - `BUILD_SHARED_LIBS`: If the value is `On`, then shared library of the project will be built. Otherwise, static library of the project will be built.

- `CIL_BUILD_EXAMPLES`: If the value is `On`, then examples of the project will also be built and installed.